### PR TITLE
Convert-YamlSequenceNodeToList 1 element array bug

### DIFF
--- a/Functions/YamlDotNet-Integration.ps1
+++ b/Functions/YamlDotNet-Integration.ps1
@@ -61,7 +61,9 @@ function Convert-YamlSequenceNodeToList($node) {
     foreach($yamlNode in $yamlNodes) {
         $list += Explode-Node $yamlNode
     }
-
-    return $list
+    
+    # fixes bug where it will return a string for 1 element arrays (loses 1 level of tree)
+     return ,[array]$list
+#    return $list
 }
 


### PR DESCRIPTION
fixes bug in Convert-YamlSequenceNodeToList where it will return a string for 1 element arrays (loses 1 level of tree). see https://github.com/scottmuc/PowerYaml/issues/12
